### PR TITLE
Added a flag for using atomic orbital basis and defined filenames inside the source code, not run.py.

### DIFF
--- a/run/run.py
+++ b/run/run.py
@@ -6,7 +6,7 @@ import os
 import sys
 import math
 
-user = 0 # 0 for Alexey, 1 for Kosuke, others should input the path they use
+user = 1 # 0 for Alexey, 1 for Kosuke, others should input the path they use
 test = 0 # 0 for 1 water molecule; 1 for 23 water molecules
 
 # input the paths of libra binary files and libra-gamess_interface source files. 
@@ -57,7 +57,7 @@ elif user==1:
     params["GMSPATH"] = "/home/e1667/install/gamess"
     params["rungms"] =  params["GMSPATH"] + "/rungms" 
     params["VERNO"] = "00"
-    params["scr_dir"] = "/home/e1667/work_NAMD/gamess_scratch"
+    params["scr_dir"] = "/home/e1667/work/scr"
 
 if test==0:
     params["gms_inp0"] = "H2O.inp"    # initial input file of GAMESS
@@ -75,6 +75,7 @@ params["dt_nucl"] = 20.0                    # time step for nuclear dynamics  ex
 params["Nsnaps"] = 5                        # the number of MD rounds
 params["Nsteps"] = 1                        # the number of MD steps per snap
 params["nconfig"] = 1                       # the number of initial nuclear/velocity geometry
+params["flag_ao"] = 1                       # flag for atomic orbital basis : option 1 -> yes. otherwise -> no. Don't choose 1 when you use PM6: PM6 calculation doesn't output it at present.
 params["MD_type"] = 1                       # option 1 -> NVT, otherwise -> NVE ; If this is 1, the parameters below should be selected.
 params["nu_therm"] = 0.01                   # shows thermostat frequency
 params["NHC_size"] = 3                      # the size of Nose-Hoover chains
@@ -119,15 +120,6 @@ elif user==1:
     params["res"] =  cwd + "/res/" #; print "res is located on ",params["res"] ; 
     params["mo_ham"] =  cwd + "/mo_ham/" #; print "mo_ham is located on ",params["mo_ham"] ;
     params["sd_ham"] = cwd + "/sd_ham/" #; print "sd_ham is located on ",params["sd_ham"] ;
-
-# output file
-#params["traj_file_prefix"] = params["res"]+"md"       # containing MD trajectories
-#params["ene_file_prefix"] = params["res"]+"ene"       # containing kinetic, potential, system, and thermostat-coupled system energies 
-#params["mu_file_prefix"] = params["res"]+"mu"         # containing dipole moment matrices
-#params["se_pop_file_prefix"] = params["res"]+"se_pop"           # containing the SE population (if velocity rescaling is applied, this is averaged over TSH trajectories). File name is defined as se_pop_"initial geometry"_"initial excitation"
-#params["sh_pop_file_prefix"] = params["res"]+"sh_pop"           # containing the SH population averaged over TSH trajectories. File name is defined in the SE way. 
-#params["se_pop_ex_file_prefix"] = params["res"]+"se_pop_ex"   # containing the SE population averaged over initial geometries. File name is se_pop_ex"initial excitation" 
-#params["sh_pop_ex_file_prefix"] = params["res"]+"sh_pop_ex"   # containing the SH population averaged over initial geometries. File name is defined in the SE way.
 
 # flags for debugging
 params["print_aux_results"] = 1             # print auxiliary results ; a large amount of files(MD, Energy trajectories, etc..) will be printed out.

--- a/src/create_gamess_input.py
+++ b/src/create_gamess_input.py
@@ -27,9 +27,9 @@ def read_gms_inp_templ(inp_filename):
     ##
     # Finds the keywords and their patterns and extracts the parameters
     # \param[in] inp_filename : The name of GAMESS input file used as template
-    # This function returns the format of GAMESS information before 
-    # coordinates of atoms.
-    #
+    # This function returns 
+    # templ : the format of GAMESS information before $DATA line.
+    # 
     # Used in:  main.py/main
 
     f = open(inp_filename,"r")
@@ -37,8 +37,10 @@ def read_gms_inp_templ(inp_filename):
     f.close()
 
     N = len(templ)
+
     for i in range(0,N):
         s = templ[i].split()
+
         if len(s) > 0 and s[0] == "$DATA":
             ikeep = i + 2
             break

--- a/src/detect.py
+++ b/src/detect.py
@@ -19,10 +19,11 @@ import sys
 import math
 
 
-def detect_columns(inp_lines):
+def detect_columns(inp_lines,flag_ao):
     ##
     # Finds the keywords and their patterns and extracts the descriptors info
     # \param[in] inp_lines The list of lines containing GAMESS output file to be unpacked
+    # \param[in] flag_ao  using atomic orbital basis: 1 - yes, otherwise - no
     # info - The returned dictionary of descriptors of the given input lines.
     #
     # Used in: detect.py/detect
@@ -53,10 +54,11 @@ def detect_columns(inp_lines):
             info["Ngbf"] = int(spline[7])
 
         # the atomic basis sets
-        if len(spline) == 3 and spline[1] == "BASIS" and spline[2] == "SET":
-            info["ab_start"] = i + 7
-        if len(spline) == 8 and spline[5] == "SHELLS":
-            info["ab_end"] = i - 2
+        if flag_ao == 1:
+            if len(spline) == 3 and spline[1] == "BASIS" and spline[2] == "SET":
+                info["ab_start"] = i + 7
+            if len(spline) == 8 and spline[5] == "SHELLS":
+                info["ab_end"] = i - 2
 
         #***********   single point calculation  ************
 
@@ -88,10 +90,11 @@ def detect_columns(inp_lines):
     return info
 
 
-def show_outputs(inp_lines,info):
+def show_outputs(inp_lines,info,flag_ao):
     ##
     # \param[in] inp_lines The list of lines containing GAMESS output file to be unpacked
     # \param[in] info The dictionary of descriptors of the given input lines.
+    # \param[in] flag_ao  using atomic orbital basis: 1 - yes, otherwise - no
     # This function shows the positions of the data elements in the analyzed file and 
     # some other auxiliary information extracted from the file
     #
@@ -117,12 +120,15 @@ def show_outputs(inp_lines,info):
     print "Ngbf = %i" % info["Ngbf"]
     print "*******************************************"
     print
-    print "******************************************"
-    print "ATOMIC BASIS SET is within %i - %i th lines." % (info["ab_start"]+1, info["ab_end"]+1)
-    for i in range(info["ab_start"],info["ab_end"]+1):
-        print inp_lines[i]
-    print "******************************************"
-    print
+
+    if flag_ao == 1:
+        print "******************************************"
+        print "ATOMIC BASIS SET is within %i - %i th lines." % (info["ab_start"]+1, info["ab_end"]+1)
+        for i in range(info["ab_start"],info["ab_end"]+1):
+            print inp_lines[i]
+        print "******************************************"
+        print
+
     print "******************************************"
     print "MOLECULAR ORBITALS is within %i - %i th lines." % (info["mo_start"]+1,info["mo_end"]+1)
     for i in range(info["mo_start"],info["mo_end"]+1):
@@ -150,22 +156,23 @@ def show_outputs(inp_lines,info):
     print
 
 
-def detect(inp_lines,flag):
+def detect(inp_lines,flag_deb,flag_ao):
     ## 
     # This function detects the positions of the valuable data in a file represented as a  
     # list of lines. It does not return the data itself, only the descriptors of where to
     # get the info about: atomic basis sets, molecular energies , molecular orbitals,
     # atomic gradients, coordinates, and labels.
     # \param[in] inp_lines The list of lines containing the file to be unpacked
-    # \param[in] flag Debug info printing: 1 - print, otherwise - don't 
+    # \param[in] flag_deb Debug info printing: 1 - print, otherwise - don't 
+    # \param[in] flag_ao  using atomic orbital basis: 1 - yes, otherwise - no
     # info - is the returned dictionary of descriptors of the given input lines
     #
     # Used in: extract.py/extract
 
-    info = detect_columns(inp_lines)
+    info = detect_columns(inp_lines,flag_ao)
 
-    if flag == 1:
-        show_outputs(inp_lines,info)
+    if flag_deb == 1:
+        show_outputs(inp_lines,info,flag_ao)
 
         print "*********************************************"
         print "detect program ends"

--- a/src/extract.py
+++ b/src/extract.py
@@ -287,12 +287,12 @@ def extract_gradient(inp_str,flag):
     return grad
 
 
-def extract(filename,flag):
+def extract(filename,flag_deb,flag_ao):
     ##
     # Finds the keywords and their patterns and extracts the parameters
-    # \param[in] l_gam : The list which contains the lines of the (GAMESS output) file.
-    # \param[in] params : The list which contains extracted data from l_gam file.
-    # \param[in] flag : a flag for debugging detect module
+    # \param[in] filename : The list which contains the lines of the (GAMESS output) file.
+    # \param[in] flag_deb     : a flag for debugging detect module
+    # \param[in] flag_ao      : a flag for using atomic oribital basis 
     # This function returns the coordinates of atoms, gradients, atomic orbital basis,
     # and molecular orbitals extracted from the file, in the form of dictionary
     #
@@ -303,16 +303,19 @@ def extract(filename,flag):
     f.close()
 
     # detect the lines including information from gamess output file
-    info = detect.detect(A,flag)
+    info = detect.detect(A,flag_deb,flag_ao)
 
     # extract information from gamess output file
-    label, Q, R = extract_coordinates(A[info["coor_start"]:info["coor_end"]+1], flag)
-    grad = extract_gradient(A[info["grad_start"]:info["grad_end"]+1], flag)
-    E, C = extract_mo(A[info["mo_start"]:info["mo_end"]+1], info["Ngbf"], flag)
-    ao = extract_ao_basis(A[info["ab_start"]:info["ab_end"]+1], label, R, flag)
+    label, Q, R = extract_coordinates(A[info["coor_start"]:info["coor_end"]+1], flag_deb)
+    grad = extract_gradient(A[info["grad_start"]:info["grad_end"]+1], flag_deb)
+    E, C = extract_mo(A[info["mo_start"]:info["mo_end"]+1], info["Ngbf"], flag_deb)
+
+    ao = []
+    if flag_ao == 1:
+        ao = extract_ao_basis(A[info["ab_start"]:info["ab_end"]+1], label, R, flag_deb)
 
     
-    if flag == 1:
+    if flag_deb == 1:
         print "********************************************"
         print "extract program ends"
         print "********************************************\n"

--- a/src/gamess_to_libra.py
+++ b/src/gamess_to_libra.py
@@ -95,22 +95,27 @@ def gamess_to_libra(params, ao, E, C, suff):
     #
     # Used in: md.py/run_MD
 
+    flag_ao = params["flag_ao"] 
+
     # 2-nd file - time "t+dt"  new
-    label, Q, R, Grad, E2, C2, ao2, tot_ene = extract(params["gms_out"],params["debug_gms_unpack"])
+    label, Q, R, Grad, E2, C2, ao2, tot_ene = extract(params["gms_out"],params["debug_gms_unpack"],flag_ao)
 
     # calculate overlap matrix of atomic and molecular orbitals
-    P11, P22, P12, P21 = overlap(ao,ao2,C,C2,params["basis_option"])
+    P11, P22, P12, P21 = overlap(ao,ao2,C,C2,params["basis_option"],flag_ao)
 
     # calculate transition dipole moment matrices in the MO basis:
     # mu_x = <i|x|j>, mu_y = <i|y|j>, mu_z = <i|z|j>
     # this is done for the "current" state only    
-    mu_x, mu_y, mu_z = transition_dipole_moments(ao2,C2)
-    mu = [mu_x, mu_y, mu_z]
+    
+    mu = []
+    if flag_ao == 1:
+        mu_x, mu_y, mu_z = transition_dipole_moments(ao2,C2)
+        mu = [mu_x, mu_y, mu_z]
 
-    if params["debug_mu_output"]==1:
-        print "mu_x:";    mu_x.show_matrix()
-        print "mu_y:";    mu_y.show_matrix()
-        print "mu_z:";    mu_z.show_matrix()
+        if params["debug_mu_output"]==1:
+            print "mu_x:";    mu_x.show_matrix()
+            print "mu_y:";    mu_y.show_matrix()
+            print "mu_z:";    mu_z.show_matrix()
  
     if params["debug_densmat_output"]==1:
         print "P11 and P22 matrixes should show orthogonality"

--- a/src/main.py
+++ b/src/main.py
@@ -68,7 +68,9 @@ def main(params):
     #sys.exit(0)
     exe_gamess(params)
 
-    label, Q, R, grad, e, c, ao, tot_ene = extract(params["gms_out"],params["debug_gms_unpack"])
+    label, Q, R, grad, e, c, ao, tot_ene = extract(params["gms_out"],params["debug_gms_unpack"],params["flag_ao"])
+
+    #print "end extract"; sys.exit(0);
 
     ao_list = []
     e_list = []

--- a/src/md.py
+++ b/src/md.py
@@ -100,7 +100,9 @@ def init_files(params):
 
                     fe = open(ene_file,"w"); fe.close();
                     ft = open(traj_file,"w"); ft.close();
-                    fm = open(mu_file,"w"); fm.close();
+
+                    if params["flag_ao"] == 1:
+                        fm = open(mu_file,"w"); fm.close();
 
     for i_ex in xrange(nstates):
 
@@ -146,6 +148,7 @@ def run_MD(syst,el,ao,E,C,params,label,Q):
     dt_elec = dt_nucl/float(el_mts)
 
     nconfig = params["nconfig"]
+    flag_ao = params["flag_ao"]
     Nsnaps = params["Nsnaps"]
     Nsteps = params["Nsteps"]
     nstates = len(params["excitations"])
@@ -169,7 +172,7 @@ def run_MD(syst,el,ao,E,C,params,label,Q):
     # make them empty (to remove older info, in case we restart calculations)
 
     init_files(params)
-
+    
     # prepare objects for MD
     ntraj = len(syst)
     nnucl = 3*syst[0].Number_of_atoms

--- a/src/overlap.py
+++ b/src/overlap.py
@@ -71,22 +71,26 @@ def MO_overlap(S,ao_i, ao_j, Ci, Cj, basis_option):
     return P
 
 
-def overlap(ao1,ao2,C1,C2,basis_sets):
+def overlap(ao1,ao2,C1,C2,basis_sets,flag_ao):
     ##
     # Finds the keywords and their patterns and extracts the parameters
     # \param[in] ao1, ao2 : atomic orbital basis at different time step.
     # \param[in] C1, C2 : molecular coefficients at different time step.
     # \param[in] basis_option : "= 1" means ab initio and "= 2" semi empirical .
+    # \param[in] flag_ao : flag using atomic orbital basis
     # This function returns overlap matrix of atomic orbitals with different time step
     # like <MO(t)|MO(t+dt)>.
     #
     # Used in: gamess_to_libra.py/gamess_to_libra
     # this is mostly a test function
 
-    S11 = AO_overlap(ao1,ao1)
-    S22 = AO_overlap(ao2,ao2)
-    S12 = AO_overlap(ao1,ao2)
-    S21 = AO_overlap(ao2,ao1)
+    N = len(ao1)
+    S11 = MATRIX(N,N); S12 = MATRIX(N,N); S21 = MATRIX(N,N); S22 = MATRIX(N,N);
+    if flag_ao == 1:
+        S11 = AO_overlap(ao1,ao1)
+        S22 = AO_overlap(ao2,ao2)
+        S12 = AO_overlap(ao1,ao2)
+        S21 = AO_overlap(ao2,ao1)
 
     P11 = MO_overlap(S11,ao1,ao1,C1,C1,basis_sets)
     P22 = MO_overlap(S22,ao2,ao2,C2,C2,basis_sets)

--- a/src/print_results.py
+++ b/src/print_results.py
@@ -43,6 +43,7 @@ def one_trajectory(i,iconf,i_ex,itraj,mol,el,ham,syst,ao,therm,mu,tot_ene,f_pot,
 
     kB = 3.166811429e-6 # Boltzmann constant in hartree unit                                                                                                 
     dt_nucl = params["dt_nucl"]
+    flag_ao = params["flag_ao"]
     MD_type = params["MD_type"]
     print_coherences = params["print_coherences"]
     nstates = el.nstates
@@ -82,13 +83,14 @@ def one_trajectory(i,iconf,i_ex,itraj,mol,el,ham,syst,ao,therm,mu,tot_ene,f_pot,
     fe.close()
         
     # Dipole moment components
-    fm = open(mu_file,"a")
-    line = "t= %8.5f " % (ij*dt_nucl)
-    for k in xrange(len(ao)):
-        line = line + " %8.5f %8.5f %8.5f " % (mu[0].get(k,k),mu[1].get(k,k),mu[2].get(k,k))
-    line = line + "\n"
-    fm.write(line)
-    fm.close()
+    if flag_ao == 1:
+        fm = open(mu_file,"a")
+        line = "t= %8.5f " % (ij*dt_nucl)
+        for k in xrange(len(ao)):
+            line = line + " %8.5f %8.5f %8.5f " % (mu[0].get(k,k),mu[1].get(k,k),mu[2].get(k,k))
+        line = line + "\n"
+        fm.write(line)
+        fm.close()
 
 
 def auxiliary(i,mol,el,ham,syst,ao,therm,mu,tot_ene,f_pot,params):


### PR DESCRIPTION
Added a flag named "flag_ao", which selects if we use atomic orbital basis.
For PM6 method implemented in  latest GAMESS,  we can't use the basis because it is not written on GAMESS output file; in this case we set the flag as 0 and don't calculate overlap matrixes and dipole moments of atomic orbital basis.

Also defined file names inside the source code, not run.py where only the directory for printing results is defined - this will be convenient for new users.