### PR TITLE
Modified functions for extracting information from GAMESS output file.

### DIFF
--- a/run/run.py
+++ b/run/run.py
@@ -72,7 +72,7 @@ elif test==1:
 # MD variables
 
 params["dt_nucl"] = 20.0                    # time step for nuclear dynamics  ex) 20 a.u. = 0.5 fsec
-params["Nsnaps"] = 5                        # the number of MD rounds
+params["Nsnaps"] = 1                        # the number of MD rounds
 params["Nsteps"] = 1                        # the number of MD steps per snap
 params["nconfig"] = 1                       # the number of initial nuclear/velocity geometry
 params["flag_ao"] = 1                       # flag for atomic orbital basis : option 1 -> yes. otherwise -> no. Don't choose 1 when you use PM6: PM6 calculation doesn't output it at present.

--- a/src/ao_basis.py
+++ b/src/ao_basis.py
@@ -26,7 +26,7 @@ elif sys.platform=="linux" or sys.platform=="linux2":
 
 def input_AO_name(l_atoms, atom_spec, basis_type, flag):
     ##
-    # \param[in] l_atom The list of all atom labels (e.g. C, C, C, H, H, ..)
+    # \param[in] l_atoms The list of all atom labels (e.g. C, C, C, H, H, ..)
     # \param[in] atom_spec A list of distinct atomic species (e.g. C, H)
     # \param[in] basis_type A list of AO types coming with the atom of each distinct type
     # (e.g. basis_type[i] = ["S","P"] implies that the atom of type i (e.g. C) has S and P orbitals) 

--- a/src/detect.py
+++ b/src/detect.py
@@ -40,6 +40,11 @@ def detect_columns(inp_lines,flag_ao):
             info["lele"] = i
             info["Nele"] = int(spline[4])
 
+        # the number of atoms
+        if len(spline) == 6 and spline[0] == "TOTAL" and spline[3]== "ATOMS":
+            info["latoms"] = i
+            info["Natoms"] = int(spline[5])
+
         # the number of occupied orbitals (alpha and beta)
         if len(spline) == 7 and spline[4] == "(ALPHA)":
             info["locc_alp"] = i
@@ -59,9 +64,7 @@ def detect_columns(inp_lines,flag_ao):
                 info["ab_start"] = i + 7
             if len(spline) == 8 and spline[5] == "SHELLS":
                 info["ab_end"] = i - 2
-
-        #***********   single point calculation  ************
-
+        
         # eigenvectors
         if len(spline) > 0 and spline[0] == "EIGENVECTORS":
             info["mo_start"] = i + 3
@@ -71,15 +74,11 @@ def detect_columns(inp_lines,flag_ao):
         # the coordinates of the atoms (in Bohr)
         if len(spline) == 4 and spline[2] == "COORDINATES" and spline[3] == "(BOHR)":
             info["coor_start"] = i + 2
-        if len(spline) == 3 and spline[0] == "INTERNUCLEAR" and spline[1] == "DISTANCES":
-            info["coor_end"] = i -2
-            info["Natoms"] = info["coor_end"] - info["coor_start"] + 1
 
         # the gradients(in Hartree/Bohr)
 
         if len(spline) == 4 and spline[0] == "GRADIENT" and spline[3] == "ENERGY":
             info["grad_start"] = i + 4
-            info["grad_end"] = info["grad_start"] + info["Natoms"] -1
 
         # total energy
 
@@ -87,6 +86,11 @@ def detect_columns(inp_lines,flag_ao):
             info["ltot_ene"] = i
             info["tot_ene"] = float(spline[4])
 
+    # end index of Coordinates and Gradients
+
+    info["coor_end"] = info["Natoms"] + info["coor_start"] - 1
+    info["grad_end"] = info["Natoms"] + info["grad_start"] - 1 
+    
     return info
 
 
@@ -101,10 +105,17 @@ def show_outputs(inp_lines,info,flag_ao):
     # Used in: detect.py/detect
 
     print "******************************************"
+    print "according to the %i th column," % (info["latoms"]+1)
+    print inp_lines[info["latoms"]]
+    print "Natoms = %i" % info["Natoms"]
+    print "*******************************************"
+    print 
+    print "******************************************"
     print "according to the %i th column," % (info["lele"]+1)
     print inp_lines[info["lele"]]
     print "Nele = %i" % info["Nele"]
     print "*******************************************"
+    print 
     print "******************************************"
     print "according to the %i th column," % (info["locc_alp"]+1)
     print inp_lines[info["locc_alp"]]
@@ -139,7 +150,6 @@ def show_outputs(inp_lines,info,flag_ao):
     print "COORDINATES OF ATOMS (in Bohr) is within %i - %i th lines." %(info["coor_start"]+1,info["coor_end"]+1)
     for i in range(info["coor_start"],info["coor_end"]+1):
         print inp_lines[i]
-    print "And the number of atoms is ",info["Natoms"]
     print "******************************************"
     print
     print "******************************************"
@@ -170,7 +180,7 @@ def detect(inp_lines,flag_deb,flag_ao):
     # Used in: extract.py/extract
 
     info = detect_columns(inp_lines,flag_ao)
-
+    
     if flag_deb == 1:
         show_outputs(inp_lines,info,flag_ao)
 

--- a/src/md.py
+++ b/src/md.py
@@ -57,6 +57,8 @@ def exe_gamess(params):
     #os.system("/usr/bin/time rungms.slurm %s 01 %s > %s" % (inp,nproc,out))
     os.system("/usr/bin/time %s %s %s %s > %s" % (rungms,inp,VERNO,nproc,out))
 
+    sys.exit(0) # debug
+
     # delete the files except input and output ones to do another GAMESS calculation.
     os.system("rm *.dat")              
     os.system("rm -r %s/*" %(scr_dir)) 

--- a/src/md.py
+++ b/src/md.py
@@ -57,7 +57,7 @@ def exe_gamess(params):
     #os.system("/usr/bin/time rungms.slurm %s 01 %s > %s" % (inp,nproc,out))
     os.system("/usr/bin/time %s %s %s %s > %s" % (rungms,inp,VERNO,nproc,out))
 
-    sys.exit(0) # debug
+    #sys.exit(0) # debug
 
     # delete the files except input and output ones to do another GAMESS calculation.
     os.system("rm *.dat")              


### PR DESCRIPTION
In detect.py,
"Natoms" has been defined in a different way: MNDO, PM1, and RM1 don't output "INTERNUCLEAR DISTANCES", so I have changed this function reading "Natoms" directly.

In extract.py,
a function reading eigenvalues(E) and eigenvectors(C) has been simplified: E and C are set directly.
Also, functions reading atomic labels have been modified to change the name of 2-character atom; in GAMESS output file, we will find capital characters for atoms(e.g. CU, CL, etc...) which are not exactly on "elements.txt"(here are Cu, Cl, etc...).

In some case, continuous word like "CL44" can be found in EIGENVECTORS lines, which is also related to 2-character atom. So, some lines are added to extract eigenvectors correctly.
