### PR TITLE
Added new list "excitations_init", which indicates the initial excited states.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,41 +3,46 @@
    This file introduces how to execute Libra-GAMESS_interface.
 
 0. Install Libra and GAMESS on your PC or server.
-   For installation, the websites below will be helpful:
+   For installation, access the websites below:
     Libra:  http://www.acsu.buffalo.edu/~alexeyak/libra/index.html
    GAMESS:  http://www.msg.ameslab.gov/gamess/
 
-1. Create a working directory,say, /home/work (outside this repository). 
+1. Create a working directory,say, /home/work . 
 
-2. There, create input files(*.inp).(H2O.inp and 23waters.inp in "run" directory are the simple examples.)
+2. There, create input files(*.inp).(H2O.inp and 23waters.inp in ".../libra-gamess_interface/run" are the simple examples.)
    For more details about how to create that, 
    please see the website http://www.msg.ameslab.gov/gamess/GAMESS_Manual/input.pdf .
    Here, Keep in mind 3 things.
    A. Only semi-empirical methods have been connected to libra so far;
       set GBASIS=MNDO, AM1, PM3, or RM1 in $BASIS section. 
    B. Set RUNTYP=GRADIENT in $CONTROL section.
-   C. Use cartesian coordinates and C1 symmetry in $DATA section:
+   C. Use cartesian coordinates in $DATA section like this:
 
-      C1
+      Cn 1
+
       C  6.000000 4.377921 -4.769170 -2.758971
       C  6.000000 3.858116 -4.331728 -3.995136
       C  6.000000 2.478331 -4.387937 -4.267327
                            .
                            .
                            .
+   
+   * set blank line between "Cn 1" and 1st coordinate line.
 
-3. For convinience, copy run_gms.py in "run" directory to the working place.
+3. For convinience, copy run_gms.py in ".../libra-gamess_interface/run" to the working place.
 
 4. Modify copied run_gms.py for calculation.
    Concretely, set variables for GAMESS, Molecular Dynamics(MD), excited electron dynamics, and debugs.
-   See the input manual in "run" directory to know more about the variables.
+   See the input manual in ".../libra-gamess_interface/run" to know more about the variables.
 
-5. Create "res" and "sd_ham" directories under the working place, where the results will be output.
+5. copy elements.txt in ".../libra-gamess_interface/run" to the working directory.
 
-6. When the precedures above are finished, it is the time to execute this program.
+6. Create "res" and "sd_ham" directories under the working place, where the results will be output.
+
+7. When the precedures above are finished, it is the time to execute this program.
    Here, 2 types of execution can be used.
    A. Only invoke "python run_gms.py" in the working place.
-   B. Use queuing system. submit_templ_gms.lsf or submit_templ_gms.slurm in "run" directory are the simple examples for using this.
+   B. Use queuing system. submit_templ_gms.lsf or submit_templ_gms.slurm in ".../libra-gamess_interface/run" are the simple examples for using this.
       Modify the files following your queuing system.   
    
-7. After the calculation finished, the results will be set in "res" directory.
+8. After the calculation finished, the results will be set in "res" directory.

--- a/run/run_gms.py
+++ b/run/run_gms.py
@@ -86,7 +86,7 @@ elif test==1:
 # MD variables
 
 params["dt_nucl"] = 20.0                    # time step in a.u. for nuclear dynamics. 20 a.u. is close to 0.5 fsec.
-params["Nsnaps"] = 5                        # the number of MD rounds
+params["Nsnaps"] = 1                        # the number of MD rounds
 params["Nsteps"] = 1                        # the number of MD steps per snap
 params["nconfig"] = 1                       # the number of initial nuclear/velocity geometry
 params["flag_ao"] = 1                       # flag for atomic orbital basis : option 1 -> yes. otherwise -> no. Don't choose 1 when you use PM6: PM6 calculation doesn't output it at present.

--- a/run/run_gms.py
+++ b/run/run_gms.py
@@ -86,7 +86,7 @@ elif test==1:
 # MD variables
 
 params["dt_nucl"] = 20.0                    # time step in a.u. for nuclear dynamics. 20 a.u. is close to 0.5 fsec.
-params["Nsnaps"] = 1                        # the number of MD rounds
+params["Nsnaps"] = 5                        # the number of MD rounds
 params["Nsteps"] = 1                        # the number of MD steps per snap
 params["nconfig"] = 1                       # the number of initial nuclear/velocity geometry
 params["flag_ao"] = 1                       # flag for atomic orbital basis : option 1 -> yes. otherwise -> no. Don't choose 1 when you use PM6: PM6 calculation doesn't output it at present.

--- a/src/md.py
+++ b/src/md.py
@@ -160,7 +160,6 @@ def run_MD(syst,el,ao,E,sd_basis,params,label,Q, active_space):
     mol = init_ensembles.init_mols(syst, ntraj, nnucl, verbose)
     therm = init_ensembles.init_therms(ntraj, nnucl, params, verbose)
 
-
     # Initialize forces and Hamiltonians **********************************************
     #epot = data["tot_ene"]  # total energy from GAMESS which is the potential energy acting on nuclei
     #write_gms_inp(data, params, mol)

--- a/src/print_results.py
+++ b/src/print_results.py
@@ -75,7 +75,7 @@ def print_one_traj(isnap, iconf, i_ex, itraj, mol, syst, mu, epot, ekin, etot, e
 
     # Energy
     fe = open(ene_file,"a")
-    fe.write("t= %8.5f ekin= %8.5f  epot= %8.5f  etot= %8.5f  eext= %8.5f curr_T= %8.5f\n" % (ij*dt_nucl, ekin, epot, etot, eext,curr_T))
+    fe.write("t= %8.5f ekin= %10.7f  epot= %10.7f  etot= %10.7f  eext= %10.7f curr_T= %8.5f\n" % (ij*dt_nucl, ekin, epot, etot, eext,curr_T))
     fe.close()
     
     if params["interface"] == "GAMESS":       


### PR DESCRIPTION
Using "excitations_init" list, we can reduce the number of initial states, i.e., reduce nstates to nstates_init defined as the length of  this list. 
For example, in the case of params["excitations"] = [ excitation(0,1,0,1), excitation(0,1,1,1), excitation(0,1,2,1), excitation(0,1,3,1)] and params["excitations_init"] = [1,2],
we use excitation(0,1,1,1) and excitation(0,1,2,1) as initial excited states.(The number order starts from 0.)

As for other commits, more significant values are printed in the energy files for debugging MD part.
